### PR TITLE
change to a relative path in Merge()

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ import gql "github.com/mattdamon108/gqlmerge/lib"
 func main(){
 	// ...
 
-	// Arg the path should be an absolute path
+	// path should be a relative path
 	schema := gql.Merge(path)
 }
 ```

--- a/lib/merge.go
+++ b/lib/merge.go
@@ -1,14 +1,21 @@
 package lib
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 )
 
 func Merge(path string) *string {
-
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(0)
+	}
 	sc := Schema{}
 	// at this moment, path should be an absolute path
-	sc.GetSchema(path)
+	sc.GetSchema(abs)
 
 	if len(sc.Files) == 0 {
 		return nil

--- a/main.go
+++ b/main.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 
 	gql "github.com/mattdamon108/gqlmerge/lib"
 )
@@ -17,13 +16,8 @@ func main() {
 	}
 
 	// TODO : needs to improve to work with a relative path.
-	abs, err := filepath.Abs(os.Args[1])
-	if err != nil {
-		fmt.Println(err)
-		os.Exit(0)
-	}
 
-	ss := gql.Merge(abs)
+	ss := gql.Merge(os.Args[1])
 
 	if ss != nil {
 		bs := []byte(*ss)


### PR DESCRIPTION
- Change a path as an argument for `Merge(path string)` to a relative path for easy use.