### PR TITLE
seperate command into package

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -1,4 +1,4 @@
-package lib
+package command
 
 import (
 	"fmt"
@@ -40,7 +40,7 @@ Options:
 		NotEnoughArgs:    "❌ Not enough arguments",
 		OutputFileNeeded: "❌ Output file argument is needed",
 		WrongOption:      "❌ Wrong options",
-		Version:          "v0.1.4",
+		Version:          "v0.1.5",
 	}
 
 	// check the number of args

--- a/main.go
+++ b/main.go
@@ -5,11 +5,12 @@ import (
 	"io/ioutil"
 	"os"
 
+	"github.com/mattdamon108/command"
 	gql "github.com/mattdamon108/gqlmerge/lib"
 )
 
 func main() {
-	cmd := gql.Command{Args: os.Args}
+	cmd := command.Command{Args: os.Args}
 	if err := cmd.Check(); err != nil {
 		fmt.Println(err)
 		os.Exit(0)


### PR DESCRIPTION
- Seperate `command.go` into package `command` which does not belong to `gqlmerge/lib`