### PR TITLE
write newline after inputs

### DIFF
--- a/lib/write.go
+++ b/lib/write.go
@@ -359,7 +359,8 @@ func (ms *MergedSchema) StitchSchema(s *Schema) string {
 
 			ms.WriteString("\n")
 		}
-		ms.WriteString("}")
+
+		ms.WriteString("}\n")
 		if j < len(s.Interfaces)-1 {
 			ms.WriteString("\n")
 		}


### PR DESCRIPTION
Due to the lack of a newline, inputs merged into single invalid text