### PR TITLE
Support for implementing multiple interfaces

### DIFF
--- a/lib/parse.go
+++ b/lib/parse.go
@@ -367,6 +367,12 @@ func (s *Schema) ParseSchema(l *Lexer) {
 					t.Impl = true
 					x := l.ConsumeIdent()
 					t.ImplType = &x
+					t.ImplTypes = append(t.ImplTypes, x)
+					for l.Peek() == '&' {
+						l.ConsumeToken('&')
+						x := l.ConsumeIdent()
+						t.ImplTypes = append(t.ImplTypes, x)
+					}
 				} else {
 					t.Impl = false
 				}
@@ -538,7 +544,7 @@ func (s *Schema) UniqueTypeName(wg *sync.WaitGroup) {
 		if _, ok := seen[v.Name]; ok {
 			for i := 0; i < j; i++ {
 				if s.TypeNames[i].Name == v.Name {
-					if s.TypeNames[i].Impl == v.Impl && s.TypeNames[i].ImplType == v.ImplType && reflect.DeepEqual(s.TypeNames[i].Props, v.Props) {
+					if reflect.DeepEqual(s.TypeNames[i].ImplTypes, v.ImplTypes) && reflect.DeepEqual(s.TypeNames[i].Props, v.Props) {
 						break
 					} else {
 

--- a/lib/types.go
+++ b/lib/types.go
@@ -49,10 +49,11 @@ type Subscription struct {
 
 type TypeName struct {
 	BaseFileInfo
-	Name     string
-	Impl     bool
-	ImplType *string
-	Props    []*Prop
+	Name      string
+	Impl      bool
+	ImplType  *string // deprecated, use ImplTypes
+	ImplTypes []string
+	Props     []*Prop
 }
 
 type Arg struct {

--- a/lib/write.go
+++ b/lib/write.go
@@ -170,8 +170,8 @@ func (ms *MergedSchema) StitchSchema(s *Schema) string {
 	for i, t := range s.TypeNames {
 		ms.buf.WriteString("type ")
 		ms.buf.WriteString(t.Name)
-		if t.Impl {
-			ms.buf.WriteString(" implements " + *t.ImplType)
+		if len(t.ImplTypes) > 0 {
+			ms.buf.WriteString(" implements " + strings.Join(t.ImplTypes, " & "))
 		}
 		ms.buf.WriteString(" {\n")
 		for _, p := range t.Props {


### PR DESCRIPTION
Example:

```graphql
type Student implements Node & Person {
  id: ID!
  name: String!
  age: Int!
  universityName: String!
}
```

For sake of backwards compatibility, we leave ImplType in place and simply add ImplTypes which contains all implemented interfaces.

Fixes #26. I wanted to add a test but couldn't find the best place to do so.
