### PR TITLE
test: type properties issue

### DIFF
--- a/test/property_type/schema/SomePayload-ko.graphql
+++ b/test/property_type/schema/SomePayload-ko.graphql
@@ -1,0 +1,3 @@
+type SomePayload {
+  type: String!
+}

--- a/test/property_type/schema/SomePayload-ok.graphql
+++ b/test/property_type/schema/SomePayload-ok.graphql
@@ -1,0 +1,3 @@
+type SomePayload {
+  someKey: String!
+}


### PR DESCRIPTION
As you can see in this PR, using `type` as a property name in a type does not work; but it should according to the spec. Right? 😄