### PR TITLE
Support the object extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.2.13
+
+- Support the object extension https://github.com/mununki/gqlmerge/pull/49
+
 ## v0.2.12
 
 - Fix where the undefined operation type is generated https://github.com/mununki/gqlmerge/pull/47

--- a/lib/graphql.go
+++ b/lib/graphql.go
@@ -60,6 +60,7 @@ type Type struct {
 	Fields       []*Field
 	Directives   []*Directive
 	Descriptions *[]string
+	Extend       bool
 }
 
 type Arg struct {

--- a/lib/lex.go
+++ b/lib/lex.go
@@ -51,6 +51,7 @@ const (
 	tokEnum                        // enum
 	tokScalar                      // scalar
 	tokUnion                       // union
+	tokExtend                      // extend
 	tokSchema                      // schema
 )
 
@@ -134,6 +135,8 @@ func (typ tokenType) String() string {
 		return "scalar"
 	case tokUnion:
 		return "union"
+	case tokExtend:
+		return "extend"
 	case tokSchema:
 		return "schema"
 	default:
@@ -328,6 +331,8 @@ func (l *lexer) next() *token {
 				return mkToken(tokScalar, "scalar")
 			case "union":
 				return mkToken(tokUnion, "union")
+			case "extend":
+				return mkToken(tokExtend, "extend")
 			case "schema":
 				return mkToken(tokSchema, "schema")
 			default:

--- a/lib/schema.go
+++ b/lib/schema.go
@@ -349,9 +349,10 @@ func (s *Schema) Parse(p *Parser) {
 			t.Filename = p.lex.filename
 			t.Line = p.lex.line
 			t.Column = p.lex.col
+			t.Descriptions = p.bufString()
 			name, _ := p.lex.consumeIdent()
 			t.Name = name.String()
-			t.Descriptions = p.bufString()
+			t.Directives = p.parseDirectives()
 
 			next := p.lex.next()
 			switch next.typ {
@@ -364,6 +365,7 @@ func (s *Schema) Parse(p *Parser) {
 					name, _ = p.lex.consumeIdent()
 					t.ImplTypes = append(t.ImplTypes, name.String())
 				}
+				t.Directives = p.parseDirectives()
 				p.lex.consumeToken(tokLBrace)
 				fallthrough
 			case tokLBrace:

--- a/lib/schema_test.go
+++ b/lib/schema_test.go
@@ -38,3 +38,39 @@ func TestGetSchema(t *testing.T) {
 	}
 
 }
+
+func TestMergeDirectives(t *testing.T) {
+	str := make([]string, 0)
+	a := []*Directive{
+		{
+			Name:          "talkable",
+			DirectiveArgs: []*DirectiveArg{},
+			Descriptions:  &str,
+		},
+	}
+	b := []*Directive{
+		{
+			Name:          "talkable",
+			DirectiveArgs: []*DirectiveArg{},
+			Descriptions:  &str,
+		},
+	}
+	c := []*Directive{
+		{
+			Name:          "walkable",
+			DirectiveArgs: []*DirectiveArg{},
+			Descriptions:  &str,
+		},
+	}
+	ds := mergeDirectives(a, b)
+
+	if len(ds) == 0 {
+		t.Fatal("should be more than 0")
+	}
+
+	ds = mergeDirectives(a, c)
+
+	if len(ds) == 0 || len(ds) == 1 {
+		t.Fatal("should be more than 1")
+	}
+}

--- a/lib/write.go
+++ b/lib/write.go
@@ -74,6 +74,7 @@ func (ms *MergedSchema) WriteSchema(s *Schema) string {
 		if len(t.ImplTypes) > 0 {
 			ms.buf.WriteString(" implements " + strings.Join(t.ImplTypes, " & "))
 		}
+		ms.stitchDirectives(t.Directives)
 		ms.buf.WriteString(" {\n")
 		for _, p := range t.Fields {
 			ms.writeDescriptions(p.Descriptions, 1, false)

--- a/test/directives/generated.graphql
+++ b/test/directives/generated.graphql
@@ -1,0 +1,14 @@
+type Person @paint {
+    name: String
+    age: Int
+    picture: Url
+}
+
+type ExampleType implements Node @deprecated {
+    id: ID
+    oldField: String
+}
+
+
+
+

--- a/test/directives/schema/object.graphql
+++ b/test/directives/schema/object.graphql
@@ -1,0 +1,10 @@
+type Person @paint {
+  name: String
+  age: Int
+  picture: Url
+}
+
+type ExampleType implements Node @deprecated {
+  id: ID
+  oldField: String
+}

--- a/test/object_extension/generated.graphql
+++ b/test/object_extension/generated.graphql
@@ -1,0 +1,11 @@
+type Person implements Node @talkable @walkable {
+    id: ID!
+    createTime: Time!
+    updateTime: Time!
+    name: String!
+    hasCar: Boolean!
+}
+
+
+
+

--- a/test/object_extension/schema/a.graphql
+++ b/test/object_extension/schema/a.graphql
@@ -1,0 +1,6 @@
+type Person implements Node @talkable{
+  id: ID!
+  createTime: Time!
+  updateTime: Time!
+  name: String!
+}

--- a/test/object_extension/schema/b.graphql
+++ b/test/object_extension/schema/b.graphql
@@ -1,0 +1,3 @@
+extend type Person @walkable {
+  hasCar: Boolean!
+}


### PR DESCRIPTION
Fixes: #48 

spec: https://spec.graphql.org/June2018/#sec-Type-Extensions

First, extensions only for objects is implemented.