### PR TITLE
Add directives support to Input type and update schema writing

### DIFF
--- a/.github/workflows/check-diff.yml
+++ b/.github/workflows/check-diff.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04]
+        os: [ubuntu-latest]
         go-version:
           - 1.20.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## v0.2.17(unreleased)
 
+- Add directive support to input https://github.com/mununki/gqlmerge/pull/58
+
 ## v0.2.16
 
 - Fix parse directive with space https://github.com/mununki/gqlmerge/pull/56

--- a/lib/graphql.go
+++ b/lib/graphql.go
@@ -130,6 +130,7 @@ type Union struct {
 type Input struct {
 	BaseFileInfo
 	Name         string
-	Fields       []*Field
 	Descriptions *[]string
+	Directives   []*Directive
+	Fields       []*Field
 }

--- a/lib/schema.go
+++ b/lib/schema.go
@@ -288,6 +288,7 @@ func (s *Schema) Parse(p *Parser) {
 			name, _ := p.lex.consumeIdent()
 			i.Name = name.String()
 			i.Descriptions = p.bufString()
+			i.Directives = p.parseDirectives()
 
 			p.lex.consumeToken(tokLBrace)
 

--- a/lib/write.go
+++ b/lib/write.go
@@ -219,7 +219,9 @@ func (ms *MergedSchema) WriteSchema(s *Schema) string {
 
 	for j, i := range s.Inputs {
 		ms.writeDescriptions(i.Descriptions, 0, true)
-		ms.buf.WriteString("input " + i.Name + " {\n")
+		ms.buf.WriteString("input " + i.Name)
+		ms.stitchDirectives(i.Directives)
+		ms.buf.WriteString(" {\n")
 
 		for _, p := range i.Fields {
 			ms.writeDescriptions(p.Descriptions, 1, true)

--- a/test/directives/generated.graphql
+++ b/test/directives/generated.graphql
@@ -25,3 +25,7 @@ type Mutation {
 
 
 
+input CompanyMetricOrder @goModel(model: "backend/ent.CompanyMetricOrder") {
+    direction: OrderDirection! = ASC
+    field: CompanyMetricOrderField!
+}

--- a/test/directives/schema/object.graphql
+++ b/test/directives/schema/object.graphql
@@ -23,3 +23,8 @@ type Mutation {
       ability: DELETE
     )
 }
+
+input CompanyMetricOrder @goModel(model: "backend/ent.CompanyMetricOrder") {
+  direction: OrderDirection! = ASC
+  field: CompanyMetricOrderField!
+}


### PR DESCRIPTION
- Introduced Directives field in Input struct in graphql.go
- Updated Parse method in schema.go to handle Directives
- Modified WriteSchema method in write.go to include Directives in output
- Added CompanyMetricOrder input type in generated.graphql and object.graphql